### PR TITLE
Dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vs/
+.vscode/
 .idea/
 SUPIR/__pycache__/
 SUPIR/models/__pycache__/

--- a/CKPT_PTH.py
+++ b/CKPT_PTH.py
@@ -1,4 +1,20 @@
-LLAVA_CLIP_PATH = 'models/clip-vit-large-patch14-336'
-LLAVA_MODEL_PATH = 'models/llava-v1.5-7b'
-SDXL_CLIP1_PATH = 'models/clip-vit-large-patch14'
-SDXL_CLIP2_CKPT_PTH = 'models/open_clip_pytorch_model.bin'
+DEFAULT_SDXL_PATH = None
+LLAVA_CLIP_PATH = None
+LLAVA_MODEL_PATH = None
+SDXL_CLIP1_PATH = None
+SDXL_CLIP2_CKPT_PTH = None
+SUPIR_CKPT_F_PTH = None
+SUPIR_CKPT_Q_PTH = None
+
+def setModelsPath(model_path, model_path2):    
+    global DEFAULT_SDXL_PATH, LLAVA_CLIP_PATH, LLAVA_MODEL_PATH, SDXL_CLIP1_PATH, SDXL_CLIP2_CKPT_PTH, SUPIR_CKPT_F_PTH, SUPIR_CKPT_Q_PTH
+
+    LLAVA_CLIP_PATH = fr'{model_path}/openai/clip-vit-large-patch14-336' if model_path is not None else 'openai/clip-vit-large-patch14-336'
+    LLAVA_MODEL_PATH = fr'{model_path}/liuhaotian/llava-v1.5-7b' if model_path is not None else 'liuhaotian/llava-v1.5-7b'
+    SDXL_CLIP1_PATH = fr'{model_path}/openai/clip-vit-large-patch14' if model_path is not None else 'openai/clip-vit-large-patch14'
+    SDXL_CLIP2_CKPT_PTH = fr'{model_path2}/laion/CLIP-ViT-bigG-14-laion2B-39B-b160k/open_clip_pytorch_model.bin' if model_path2 is not None else 'laion/CLIP-ViT-bigG-14-laion2B-39B-b160k/open_clip_pytorch_model.bin'
+    DEFAULT_SDXL_PATH = fr'{model_path}/checkpoints/RunDiffusion/Juggernaut-XL-v9/Juggernaut-XL_v9_RunDiffusionPhoto_v2.safetensors' if model_path is not None else 'RunDiffusion/Juggernaut-XL-v9/Juggernaut-XL_v9_RunDiffusionPhoto_v2.safetensors' 
+    SUPIR_CKPT_F_PTH = fr'{model_path}/checkpoints/ashleykleynhans/SUPIR/SUPIR-v0F.ckpt' if model_path is not None else 'ashleykleynhans/SUPIR/SUPIR-v0F.ckpt' 
+    SUPIR_CKPT_Q_PTH = fr'{model_path}/checkpoints/ashleykleynhans/SUPIR/SUPIR-v0Q.ckpt' if model_path is not None else 'ashleykleynhans/SUPIR/SUPIR-v0Q.ckpt' 
+    
+

--- a/SUPIR/utils/devices.py
+++ b/SUPIR/utils/devices.py
@@ -1,7 +1,7 @@
 import sys
 import contextlib
 from functools import lru_cache
-
+import gc
 import torch
 #from modules import errors
 
@@ -47,30 +47,47 @@ def torch_gc():
 
     if has_mps():
         mac_specific.torch_mps_gc()
-
+    gc.collect()
 
 def enable_tf32():
     if torch.cuda.is_available():
 
         # enabling benchmark option seems to enable a range of cards to do fp16 when they otherwise can't
         # see https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/4407
-        if any(torch.cuda.get_device_capability(devid) == (7, 5) for devid in range(0, torch.cuda.device_count())):
+        if cuda_no_autocast():
             torch.backends.cudnn.benchmark = True
 
         torch.backends.cuda.matmul.allow_tf32 = True
         torch.backends.cudnn.allow_tf32 = True
 
 
-enable_tf32()
 #errors.run(enable_tf32, "Enabling TF32")
-
+torch.backends.cudnn.allow_tf32 = False
+torch.backends.cuda.allow_tf32 = False
+fp8: bool = False
 cpu = torch.device("cpu")
 device = device_interrogate = device_gfpgan = device_esrgan = device_codeformer = torch.device("cuda")
 dtype = torch.float16
 dtype_vae = torch.float16
 dtype_unet = torch.float16
+dtype_inference: torch.dtype = torch.float16
 unet_needs_upcast = False
 
+patch_module_list = [
+    torch.nn.Linear,
+    torch.nn.Conv2d,
+    torch.nn.MultiheadAttention,
+    torch.nn.GroupNorm,
+    torch.nn.LayerNorm,
+]
+
+def cuda_no_autocast(device_id=None) -> bool:
+    if device_id is None:
+        device_id = torch.cuda.current_device()
+    return (
+        torch.cuda.get_device_capability(device_id) == (7, 5)
+        and torch.cuda.get_device_name(device_id).startswith("NVIDIA GeForce GTX 16")
+    )
 
 def cond_cast_unet(input):
     return input.to(dtype_unet) if unet_needs_upcast else input
@@ -136,3 +153,77 @@ def first_time_calculation():
     x = torch.zeros((1, 1, 3, 3)).to(device, dtype)
     conv2d = torch.nn.Conv2d(1, 1, (3, 3)).to(device, dtype)
     conv2d(x)
+
+def manual_cast_forward(target_dtype):
+    def forward_wrapper(self, *args, **kwargs):
+        if any(
+            isinstance(arg, torch.Tensor) and arg.dtype != target_dtype
+            for arg in args
+        ):
+            args = [arg.to(target_dtype) if isinstance(arg, torch.Tensor) else arg for arg in args]
+            kwargs = {k: v.to(target_dtype) if isinstance(v, torch.Tensor) else v for k, v in kwargs.items()}
+
+        org_dtype = target_dtype
+        for param in self.parameters():
+            if param.dtype != target_dtype:
+                org_dtype = param.dtype
+                break
+
+        if org_dtype != target_dtype:
+            self.to(target_dtype)
+        result = self.org_forward(*args, **kwargs)
+        if org_dtype != target_dtype:
+            self.to(org_dtype)
+
+        if target_dtype != dtype_inference:
+            if isinstance(result, tuple):
+                result = tuple(
+                    i.to(dtype_inference)
+                    if isinstance(i, torch.Tensor)
+                    else i
+                    for i in result
+                )
+            elif isinstance(result, torch.Tensor):
+                result = result.to(dtype_inference)
+        return result
+    return forward_wrapper
+
+@contextlib.contextmanager
+def manual_cast(target_dtype):
+    applied = False
+    for module_type in patch_module_list:
+        if hasattr(module_type, "org_forward"):
+            continue
+        applied = True
+        org_forward = module_type.forward
+        if module_type == torch.nn.MultiheadAttention:
+            module_type.forward = manual_cast_forward(torch.float32)
+        else:
+            module_type.forward = manual_cast_forward(target_dtype)
+        module_type.org_forward = org_forward
+    try:
+        yield None
+    finally:
+        if applied:
+            for module_type in patch_module_list:
+                if hasattr(module_type, "org_forward"):
+                    module_type.forward = module_type.org_forward
+                    delattr(module_type, "org_forward")
+
+def autocast(disable=False, _dtype=torch.bfloat16):
+    if disable:
+        return contextlib.nullcontext()
+
+    if fp8 and device==cpu:
+        return torch.autocast("cpu", dtype=_dtype, enabled=True)
+
+    if fp8 and dtype_inference == torch.float32:
+        return manual_cast(dtype)
+
+    if dtype == torch.float32 or dtype_inference == torch.float32:
+        return contextlib.nullcontext()
+
+    if has_mps() or cuda_no_autocast():
+        return manual_cast(dtype)
+
+    return torch.autocast("cuda")

--- a/SUPIR/utils/model_fetch.py
+++ b/SUPIR/utils/model_fetch.py
@@ -1,13 +1,45 @@
-from huggingface_hub import snapshot_download
+from huggingface_hub import snapshot_download, hf_hub_download
+from pathlib import PureWindowsPath
 import os
+import sys
 
 models_folder = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", 'models'))
 
 
-def get_model(model_repo: str):
-    model_name = model_repo.split('/')[-1]
-    model_path = os.path.join(models_folder, model_name)
-    if not os.path.exists(model_path):
-        model_folder = model_repo.split('/')[1]
-        snapshot_download(model_repo, local_dir=os.path.join(models_folder, model_folder), local_dir_use_symlinks=False)
-    return model_path
+def get_model(model_repo: str):    
+    if sys.platform == 'win32':
+        model_repo = '/'.join(PureWindowsPath(model_repo).parts)
+
+    extensions = ['ckpt', 'safetensors', 'bin']
+    model_repo_splitted = model_repo.split('/')
+    model_file = None
+    if len(model_repo_splitted) > 2: #model folder was provided
+        if any(x in model_repo for x in extensions):    #specific file was provided        
+            if '.bin' in model_repo:
+                model_path = '/'.join(model_repo_splitted[0:-1])
+            else:
+                model_path = '/'.join(model_repo_splitted[0:-3])
+
+            model_file = model_repo_splitted[-1]
+            model_id =  fr"{model_repo_splitted[-3]}/{model_repo_splitted[-2]}"  
+            model = fr"{model_path}/{model_file}"
+
+            if not os.path.exists(model):        
+                snapshot_download(model_id, allow_patterns=model_file, local_dir=model_path, local_dir_use_symlinks=False) 
+                #hf_hub_download(repo_id=model_id, filename=model_file, local_dir=model_path)                            
+            return model        
+        else: # entire repo
+            model_path = model_repo
+            model_id =  fr"{model_repo_splitted[-2]}/{model_repo_splitted[-1]}"
+            
+            if not os.path.exists(model_path):        
+                snapshot_download(model_id, local_dir=model_path, local_dir_use_symlinks=False)            
+            return model_path
+    else: #use default model folder
+        model_id = model_repo
+        model_path = os.path.join(models_folder, model_id)
+        
+        if not os.path.exists(model_path):        
+            snapshot_download(model_id, local_dir=model_path, local_dir_use_symlinks=False)            
+        return model_path    
+

--- a/SUPIR/utils/models_utils.py
+++ b/SUPIR/utils/models_utils.py
@@ -1,0 +1,128 @@
+import platform
+import os
+import torch
+from  SUPIR.utils import shared, devices
+
+checkpoint_dict_replacements_sd1 = {
+    'cond_stage_model.transformer.embeddings.': 'cond_stage_model.transformer.text_model.embeddings.',
+    'cond_stage_model.transformer.encoder.': 'cond_stage_model.transformer.text_model.encoder.',
+    'cond_stage_model.transformer.final_layer_norm.': 'cond_stage_model.transformer.text_model.final_layer_norm.',
+}
+
+checkpoint_dict_replacements_sd2_turbo = { # Converts SD 2.1 Turbo from SGM to LDM format.
+    'conditioner.embedders.0.': 'cond_stage_model.',
+}
+def transform_checkpoint_dict_key(k, replacements):
+    for text, replacement in replacements.items():
+        if k.startswith(text):
+            k = replacement + k[len(text):]
+
+    return k
+
+
+def get_state_dict(d):
+
+    pl_sd = d.pop("state_dict", d)
+    pl_sd.pop("state_dict", None)
+
+    is_sd2_turbo = 'conditioner.embedders.0.model.ln_final.weight' in pl_sd and pl_sd['conditioner.embedders.0.model.ln_final.weight'].size()[0] == 1024
+
+    sd = {}
+    for k, v in pl_sd.items():
+        if is_sd2_turbo:
+            new_key = transform_checkpoint_dict_key(k, checkpoint_dict_replacements_sd2_turbo)
+        else:
+            new_key = transform_checkpoint_dict_key(k, checkpoint_dict_replacements_sd1)
+
+        if new_key is not None:
+            sd[new_key] = v
+
+    pl_sd.clear()
+    pl_sd.update(sd)
+
+    return pl_sd
+
+def load_state_dict(ckpt_path, map_location='cpu'):
+    _, extension = os.path.splitext(ckpt_path)
+    platform_name = platform.uname()
+    isWSL2 = 'WSL2' in platform_name.release
+
+    if extension.lower() == ".safetensors":
+        import safetensors.torch        
+        if not isWSL2:
+            state_dict = safetensors.torch.load_file(ckpt_path, device=map_location)
+        else:
+            state_dict = safetensors.torch.load(open(ckpt_path, 'rb').read())
+            state_dict = {k: v.to(map_location) for k, v in state_dict.items()}
+    else:
+        state_dict = get_state_dict(torch.load(ckpt_path, map_location=torch.device(map_location)))
+    state_dict = get_state_dict(state_dict)
+    print(f'Loaded state_dict from [{ckpt_path}]')
+    return state_dict
+
+def check_fp8(model):
+    if model is None:
+        return None
+    if devices.get_optimal_device_name() == "mps":
+        enable_fp8 = False
+    elif shared.opts.fp8_storage == True:
+        enable_fp8 = True    
+    else:
+        enable_fp8 = False
+    return enable_fp8
+
+def load_model_weights(model, state_dict, vae_file=None):
+
+    if devices.fp8:
+        model.half()
+   
+    model.load_state_dict(state_dict, strict=False)    
+
+    del state_dict
+
+    if shared.opts.opt_channelslast:
+        model.to(memory_format=torch.channels_last)        
+        #print('apply channels_last')
+
+    if shared.opts.half_mode == False:
+        model.float()        
+        devices.dtype_unet = torch.float32        
+        #print('apply float')
+    else:
+        vae = model.first_stage_model
+        depth_model = getattr(model, 'depth_model', None)
+
+        if shared.opts.half_mode:
+            model.half()
+        
+        model.first_stage_model = vae
+        if depth_model:
+            model.depth_model = depth_model
+        #print('apply half')
+
+    for module in model.modules():
+        if hasattr(module, 'fp16_weight'):
+            del module.fp16_weight
+        if hasattr(module, 'fp16_bias'):
+            del module.fp16_bias
+
+    if check_fp8(model):
+        devices.fp8 = True
+        #first_stage = model.first_stage_model
+        #model.first_stage_model = None
+        for module in model.modules():
+            if isinstance(module, (torch.nn.Conv2d, torch.nn.Linear)):               
+                module.to(torch.float8_e4m3fn)
+        #model.first_stage_model = first_stage
+        #print("apply fp8")
+    else:
+        devices.fp8 = False
+
+    devices.unet_needs_upcast = shared.opts.upcast_sampling  and devices.dtype == torch.float16 and devices.dtype_unet == torch.float16
+
+    model.first_stage_model.to(devices.dtype_vae)
+
+    if hasattr(model, 'logvar'):
+        model.logvar = model.logvar.to(devices.device) 
+
+   

--- a/SUPIR/utils/sd_disable_initialization.py
+++ b/SUPIR/utils/sd_disable_initialization.py
@@ -1,0 +1,231 @@
+#import ldm.modules.encoders.modules
+import sgm.modules.encoders.modules
+import open_clip
+import torch
+import transformers.utils.hub
+
+
+class ReplaceHelper:
+    def __init__(self):
+        self.replaced = []
+
+    def replace(self, obj, field, func):
+        original = getattr(obj, field, None)
+        if original is None:
+            return None
+
+        self.replaced.append((obj, field, original))
+        setattr(obj, field, func)
+
+        return original
+
+    def restore(self):
+        for obj, field, original in self.replaced:
+            setattr(obj, field, original)
+
+        self.replaced.clear()
+
+
+class DisableInitialization(ReplaceHelper):
+    """
+    When an object of this class enters a `with` block, it starts:
+    - preventing torch's layer initialization functions from working
+    - changes CLIP and OpenCLIP to not download model weights
+    - changes CLIP to not make requests to check if there is a new version of a file you already have
+
+    When it leaves the block, it reverts everything to how it was before.
+
+    Use it like this:
+    ```
+    with DisableInitialization():
+        do_things()
+    ```
+    """
+
+    def __init__(self, disable_clip=True):
+        super().__init__()
+        self.disable_clip = disable_clip
+
+    def replace(self, obj, field, func):
+        original = getattr(obj, field, None)
+        if original is None:
+            return None
+
+        self.replaced.append((obj, field, original))
+        setattr(obj, field, func)
+
+        return original
+
+    def __enter__(self):
+        def do_nothing(*args, **kwargs):
+            pass
+
+        def create_model_and_transforms_without_pretrained(*args, pretrained=None, **kwargs):
+            return self.create_model_and_transforms(*args, pretrained=None, **kwargs)
+
+        def CLIPTextModel_from_pretrained(pretrained_model_name_or_path, *model_args, **kwargs):
+            res = self.CLIPTextModel_from_pretrained(None, *model_args, config=pretrained_model_name_or_path, state_dict={}, **kwargs)
+            res.name_or_path = pretrained_model_name_or_path
+            return res
+
+        def transformers_modeling_utils_load_pretrained_model(*args, **kwargs):
+            args = args[0:3] + ('/', ) + args[4:]  # resolved_archive_file; must set it to something to prevent what seems to be a bug
+            return self.transformers_modeling_utils_load_pretrained_model(*args, **kwargs)
+
+        def transformers_utils_hub_get_file_from_cache(original, url, *args, **kwargs):
+
+            # this file is always 404, prevent making request
+            if url == 'https://huggingface.co/openai/clip-vit-large-patch14/resolve/main/added_tokens.json' or url == 'openai/clip-vit-large-patch14' and args[0] == 'added_tokens.json':
+                return None
+
+            try:
+                res = original(url, *args, local_files_only=True, **kwargs)
+                if res is None:
+                    res = original(url, *args, local_files_only=False, **kwargs)
+                return res
+            except Exception:
+                return original(url, *args, local_files_only=False, **kwargs)
+
+        def transformers_utils_hub_get_from_cache(url, *args, local_files_only=False, **kwargs):
+            return transformers_utils_hub_get_file_from_cache(self.transformers_utils_hub_get_from_cache, url, *args, **kwargs)
+
+        def transformers_tokenization_utils_base_cached_file(url, *args, local_files_only=False, **kwargs):
+            return transformers_utils_hub_get_file_from_cache(self.transformers_tokenization_utils_base_cached_file, url, *args, **kwargs)
+
+        def transformers_configuration_utils_cached_file(url, *args, local_files_only=False, **kwargs):
+            return transformers_utils_hub_get_file_from_cache(self.transformers_configuration_utils_cached_file, url, *args, **kwargs)
+
+        self.replace(torch.nn.init, 'kaiming_uniform_', do_nothing)
+        self.replace(torch.nn.init, '_no_grad_normal_', do_nothing)
+        self.replace(torch.nn.init, '_no_grad_uniform_', do_nothing)
+
+        if self.disable_clip:
+            self.create_model_and_transforms = self.replace(open_clip, 'create_model_and_transforms', create_model_and_transforms_without_pretrained)
+            self.CLIPTextModel_from_pretrained = self.replace(sgm.modules.encoders.modules.CLIPTextModel, 'from_pretrained', CLIPTextModel_from_pretrained)
+            self.transformers_modeling_utils_load_pretrained_model = self.replace(transformers.modeling_utils.PreTrainedModel, '_load_pretrained_model', transformers_modeling_utils_load_pretrained_model)
+            self.transformers_tokenization_utils_base_cached_file = self.replace(transformers.tokenization_utils_base, 'cached_file', transformers_tokenization_utils_base_cached_file)
+            self.transformers_configuration_utils_cached_file = self.replace(transformers.configuration_utils, 'cached_file', transformers_configuration_utils_cached_file)
+            self.transformers_utils_hub_get_from_cache = self.replace(transformers.utils.hub, 'get_from_cache', transformers_utils_hub_get_from_cache)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.restore()
+
+
+class InitializeOnMeta(ReplaceHelper):
+    """
+    Context manager that causes all parameters for linear/conv2d/mha layers to be allocated on meta device,
+    which results in those parameters having no values and taking no memory. model.to() will be broken and
+    will need to be repaired by using LoadStateDictOnMeta below when loading params from state dict.
+
+    Usage:
+    ```
+    with sd_disable_initialization.InitializeOnMeta():
+        sd_model = instantiate_from_config(sd_config.model)
+    ```
+    """
+
+    def __enter__(self):
+        # if shared.cmd_opts.disable_model_loading_ram_optimization:
+        #     return
+
+        def set_device(x):
+            x["device"] = "meta"
+            return x
+
+        linear_init = self.replace(torch.nn.Linear, '__init__', lambda *args, **kwargs: linear_init(*args, **set_device(kwargs)))
+        conv2d_init = self.replace(torch.nn.Conv2d, '__init__', lambda *args, **kwargs: conv2d_init(*args, **set_device(kwargs)))
+        mha_init = self.replace(torch.nn.MultiheadAttention, '__init__', lambda *args, **kwargs: mha_init(*args, **set_device(kwargs)))
+        self.replace(torch.nn.Module, 'to', lambda *args, **kwargs: None)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.restore()
+
+
+class LoadStateDictOnMeta(ReplaceHelper):
+    """
+    Context manager that allows to read parameters from state_dict into a model that has some of its parameters in the meta device.
+    As those parameters are read from state_dict, they will be deleted from it, so by the end state_dict will be mostly empty, to save memory.
+    Meant to be used together with InitializeOnMeta above.
+
+    Usage:
+    ```
+    with sd_disable_initialization.LoadStateDictOnMeta(state_dict):
+        model.load_state_dict(state_dict, strict=False)
+    ```
+    """
+
+    def __init__(self, state_dict, device, weight_dtype_conversion=None):
+        super().__init__()
+        self.state_dict = state_dict
+        self.device = device
+        self.weight_dtype_conversion = weight_dtype_conversion or {}
+        self.default_dtype = self.weight_dtype_conversion.get('')
+
+    def get_weight_dtype(self, key):
+        key_first_term, _ = key.split('.', 1)
+        return self.weight_dtype_conversion.get(key_first_term, self.default_dtype)
+
+    def __enter__(self):
+        # if shared.cmd_opts.disable_model_loading_ram_optimization:
+        #     return
+
+        sd = self.state_dict
+        device = self.device
+
+        def load_from_state_dict(original, module, state_dict, prefix, *args, **kwargs):
+            used_param_keys = []
+
+            for name, param in module._parameters.items():
+                if param is None:
+                    continue
+
+                key = prefix + name
+                sd_param = sd.pop(key, None)
+                if sd_param is not None:
+                    state_dict[key] = sd_param.to(dtype=self.get_weight_dtype(key))
+                    used_param_keys.append(key)
+
+                if param.is_meta:
+                    dtype = sd_param.dtype if sd_param is not None else param.dtype
+                    module._parameters[name] = torch.nn.parameter.Parameter(torch.zeros_like(param, device=device, dtype=dtype), requires_grad=param.requires_grad)
+
+            for name in module._buffers:
+                key = prefix + name
+
+                sd_param = sd.pop(key, None)
+                if sd_param is not None:
+                    state_dict[key] = sd_param
+                    used_param_keys.append(key)
+
+            original(module, state_dict, prefix, *args, **kwargs)
+
+            for key in used_param_keys:
+                state_dict.pop(key, None)
+
+        def load_state_dict(original, module, state_dict, strict=True):
+            """torch makes a lot of copies of the dictionary with weights, so just deleting entries from state_dict does not help
+            because the same values are stored in multiple copies of the dict. The trick used here is to give torch a dict with
+            all weights on meta device, i.e. deleted, and then it doesn't matter how many copies torch makes.
+
+            In _load_from_state_dict, the correct weight will be obtained from a single dict with the right weights (sd).
+
+            The dangerous thing about this is if _load_from_state_dict is not called, (if some exotic module overloads
+            the function and does not call the original) the state dict will just fail to load because weights
+            would be on the meta device.
+            """
+
+            if state_dict is sd:
+                state_dict = {k: v.to(device="meta", dtype=v.dtype) for k, v in state_dict.items()}
+
+            original(module, state_dict, strict=strict)
+
+        module_load_state_dict = self.replace(torch.nn.Module, 'load_state_dict', lambda *args, **kwargs: load_state_dict(module_load_state_dict, *args, **kwargs))
+        module_load_from_state_dict = self.replace(torch.nn.Module, '_load_from_state_dict', lambda *args, **kwargs: load_from_state_dict(module_load_from_state_dict, *args, **kwargs))
+        linear_load_from_state_dict = self.replace(torch.nn.Linear, '_load_from_state_dict', lambda *args, **kwargs: load_from_state_dict(linear_load_from_state_dict, *args, **kwargs))
+        conv2d_load_from_state_dict = self.replace(torch.nn.Conv2d, '_load_from_state_dict', lambda *args, **kwargs: load_from_state_dict(conv2d_load_from_state_dict, *args, **kwargs))
+        mha_load_from_state_dict = self.replace(torch.nn.MultiheadAttention, '_load_from_state_dict', lambda *args, **kwargs: load_from_state_dict(mha_load_from_state_dict, *args, **kwargs))
+        layer_norm_load_from_state_dict = self.replace(torch.nn.LayerNorm, '_load_from_state_dict', lambda *args, **kwargs: load_from_state_dict(layer_norm_load_from_state_dict, *args, **kwargs))
+        group_norm_load_from_state_dict = self.replace(torch.nn.GroupNorm, '_load_from_state_dict', lambda *args, **kwargs: load_from_state_dict(group_norm_load_from_state_dict, *args, **kwargs))
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.restore()

--- a/SUPIR/utils/shared.py
+++ b/SUPIR/utils/shared.py
@@ -1,0 +1,8 @@
+import types
+
+opts = pipe_encode = types.SimpleNamespace() 
+opts.fp8_storage=False
+opts.opt_channelslast=False
+opts.half_mode = False
+opts.upcast_sampling = False
+

--- a/download_models.py
+++ b/download_models.py
@@ -50,6 +50,7 @@ def download_file(url, folder_path, file_name=None):
 # Define the folders and their corresponding file URLs with optional file names
 checkpoint_files = {
     CHECKPOINT_DIR: [
+        ('https://civitai.com/api/download/models/360292?token=22c5b4cb1989d2c3ff29f222d2840884','WildCardX_XL_Lightning.safetensors')
         ('https://huggingface.co/RunDiffusion/Juggernaut-XL-v9/resolve/main/Juggernaut-XL_v9_RunDiffusionPhoto_v2.safetensors', 'Juggernaut-XL_v9_RunDiffusionPhoto_v2.safetensors'),
         ('https://huggingface.co/ashleykleynhans/SUPIR/resolve/main/SUPIR-v0F.ckpt', 'SUPIR-v0F.ckpt'),
         ('https://huggingface.co/ashleykleynhans/SUPIR/resolve/main/SUPIR-v0Q.ckpt', 'SUPIR-v0Q.ckpt')        

--- a/download_models.py
+++ b/download_models.py
@@ -1,8 +1,16 @@
+import sys
 import os
 import requests
 from tqdm import tqdm
 from huggingface_hub import snapshot_download
+from pathlib import PureWindowsPath
 
+MODEL_HOME = os.environ.get('MODEL_HOME', 'models')
+CHECKPOINT_DIR= os.path.join(MODEL_HOME, 'checkpoints')
+
+if sys.platform == 'win32':
+    MODEL_HOME = '/'.join(PureWindowsPath(MODEL_HOME).parts)
+    CHECKPOINT_DIR= '/'.join(PureWindowsPath(CHECKPOINT_DIR).parts)
 
 def create_directory(path):
     """Create directory if it does not exist."""
@@ -40,17 +48,16 @@ def download_file(url, folder_path, file_name=None):
 
 
 # Define the folders and their corresponding file URLs with optional file names
-folders_and_files = {
-    os.path.join('models'): [
-        ('https://huggingface.co/laion/CLIP-ViT-bigG-14-laion2B-39B-b160k/resolve/main/open_clip_pytorch_model.bin', None),
-        ('https://huggingface.co/ashleykleynhans/SUPIR/resolve/main/SUPIR-v0F.ckpt', 'v0F.ckpt'),
-        ('https://huggingface.co/ashleykleynhans/SUPIR/resolve/main/SUPIR-v0Q.ckpt', 'v0Q.ckpt')
+checkpoint_files = {
+    CHECKPOINT_DIR: [
+        ('https://huggingface.co/RunDiffusion/Juggernaut-XL-v9/resolve/main/Juggernaut-XL_v9_RunDiffusionPhoto_v2.safetensors', 'Juggernaut-XL_v9_RunDiffusionPhoto_v2.safetensors'),
+        ('https://huggingface.co/ashleykleynhans/SUPIR/resolve/main/SUPIR-v0F.ckpt', 'SUPIR-v0F.ckpt'),
+        ('https://huggingface.co/ashleykleynhans/SUPIR/resolve/main/SUPIR-v0Q.ckpt', 'SUPIR-v0Q.ckpt')        
     ]
 }
 
-
 if __name__ == '__main__':
-    for folder, files in folders_and_files.items():
+    for folder, files in checkpoint_files.items():
         create_directory(folder)
         for file_url, file_name in files:
             download_file(file_url, folder, file_name)
@@ -58,15 +65,33 @@ if __name__ == '__main__':
     llava_model = os.getenv('LLAVA_MODEL', 'liuhaotian/llava-v1.5-7b')
     llava_clip_model = 'openai/clip-vit-large-patch14-336'
     sdxl_clip_model = 'openai/clip-vit-large-patch14'
+    sdxl_clip2_model ='laion/CLIP-ViT-bigG-14-laion2B-39B-b160k/open_clip_pytorch_model.bin' 
 
     print(f'Downloading LLaVA model: {llava_model}')
-    model_folder = llava_model.split('/')[1]
-    snapshot_download(llava_model, local_dir=os.path.join("models", model_folder), local_dir_use_symlinks=False)
+    model_folder = fr"{MODEL_HOME}/{llava_model}"
+    if not os.path.exists(model_folder):
+        snapshot_download(llava_model, local_dir=model_folder, local_dir_use_symlinks=False)
+    else:        
+        print(f'Model already exists: {llava_model}')
 
     print(f'Downloading LLaVA CLIP model: {llava_clip_model}')
-    model_folder = llava_clip_model.split('/')[1]
-    snapshot_download(llava_clip_model, local_dir=os.path.join("models", model_folder), local_dir_use_symlinks=False)
+    model_folder = fr"{MODEL_HOME}/{llava_clip_model}"
+    if not os.path.exists(model_folder):
+        snapshot_download(llava_clip_model, local_dir=model_folder, local_dir_use_symlinks=False)
+    else:
+        print(f'Model already exists: {llava_clip_model}')
 
     print(f'Downloading SDXL CLIP model: {sdxl_clip_model}')
-    model_folder = sdxl_clip_model.split('/')[1]
-    snapshot_download(sdxl_clip_model, local_dir=os.path.join("models", model_folder), local_dir_use_symlinks=False)
+    model_folder = fr"{MODEL_HOME}/{sdxl_clip_model}"
+    if not os.path.exists(model_folder):
+        snapshot_download(sdxl_clip_model, local_dir=model_folder, local_dir_use_symlinks=False)
+    else:
+        print(f'Model already exists: {sdxl_clip_model}')
+
+    print(f'Downloading SDXL CLIP 2 model: {sdxl_clip2_model}')    
+    model_id = fr"{sdxl_clip2_model.split('/')[-3]}/{sdxl_clip2_model.split('/')[-2]}"
+    model_folder = fr"{MODEL_HOME}/{model_id}"
+    if not os.path.exists(fr"{MODEL_HOME}/{sdxl_clip2_model}"):
+        snapshot_download(model_id, allow_patterns=sdxl_clip2_model.split('/')[-1], local_dir=model_folder, local_dir_use_symlinks=False)
+    else:
+        print(f'Model already exists: {sdxl_clip2_model}')

--- a/download_models.py
+++ b/download_models.py
@@ -50,7 +50,7 @@ def download_file(url, folder_path, file_name=None):
 # Define the folders and their corresponding file URLs with optional file names
 checkpoint_files = {
     CHECKPOINT_DIR: [
-        ('https://civitai.com/api/download/models/360292?token=22c5b4cb1989d2c3ff29f222d2840884','WildCardX_XL_Lightning.safetensors')
+        ('https://civitai.com/api/download/models/360292?token=22c5b4cb1989d2c3ff29f222d2840884','WildCardX_XL_Lightning.safetensors'),
         ('https://huggingface.co/RunDiffusion/Juggernaut-XL-v9/resolve/main/Juggernaut-XL_v9_RunDiffusionPhoto_v2.safetensors', 'Juggernaut-XL_v9_RunDiffusionPhoto_v2.safetensors'),
         ('https://huggingface.co/ashleykleynhans/SUPIR/resolve/main/SUPIR-v0F.ckpt', 'SUPIR-v0F.ckpt'),
         ('https://huggingface.co/ashleykleynhans/SUPIR/resolve/main/SUPIR-v0Q.ckpt', 'SUPIR-v0Q.ckpt')        

--- a/llava/llava_agent.py
+++ b/llava/llava_agent.py
@@ -16,7 +16,7 @@ import glob as gb
 
 
 class LLavaAgent:
-    def __init__(self, model_path, device='cuda', conv_mode='vicuna_v1', load_8bit=False, load_4bit=False):
+    def __init__(self, model_path, device='cuda:0', conv_mode='vicuna_v1', load_8bit=False, load_4bit=False):
         self.device = device
         if torch.device(self.device).index is not None:
             device_map = {'model': torch.device(self.device).index, 'lm_head': torch.device(self.device).index}

--- a/llava/model/builder.py
+++ b/llava/model/builder.py
@@ -23,12 +23,15 @@ from llava.model import *
 from llava.constants import DEFAULT_IMAGE_PATCH_TOKEN, DEFAULT_IM_START_TOKEN, DEFAULT_IM_END_TOKEN
 
 
-def load_pretrained_model(model_path, model_base, model_name, load_8bit=False, load_4bit=False, device_map="auto", device="cuda"):
+def load_pretrained_model(model_path, model_base, model_name, load_8bit=False, load_4bit=False, device_map="auto", device="cuda:0"):
     kwargs = {"device_map": device_map}
+
+    if device != "cuda:0":
+        kwargs['device_map'] = {"": device}
 
     if load_8bit:
         kwargs['load_in_8bit'] = True
-    elif load_4bit:
+    elif load_4bit:        
         kwargs['quantization_config'] = BitsAndBytesConfig(
             load_in_4bit=True,
             bnb_4bit_compute_dtype=torch.float16,

--- a/llava/model/multimodal_encoder/clip_encoder.py
+++ b/llava/model/multimodal_encoder/clip_encoder.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn as nn
 
 from transformers import CLIPVisionModel, CLIPImageProcessor, CLIPVisionConfig
-from CKPT_PTH import LLAVA_CLIP_PATH
+import CKPT_PTH
 from SUPIR.utils.model_fetch import get_model
 
 
@@ -17,7 +17,7 @@ class CLIPVisionTower(nn.Module):
         print(f'Loading vision tower: {self.vision_tower_name}')
         self.select_layer = args.mm_vision_select_layer
         self.select_feature = getattr(args, 'mm_vision_select_feature', 'patch')
-        llava_path = get_model("openai/clip-vit-large-patch14-336")
+        llava_path = get_model(CKPT_PTH.LLAVA_CLIP_PATH)
         if not delay_load:
             self.load_model()
         else:
@@ -25,7 +25,7 @@ class CLIPVisionTower(nn.Module):
             self.cfg_only = CLIPVisionConfig.from_pretrained(llava_path)
 
     def load_model(self):
-        llava_path = get_model("openai/clip-vit-large-patch14-336")
+        llava_path = get_model(CKPT_PTH.LLAVA_CLIP_PATH)
         self.image_processor = CLIPImageProcessor.from_pretrained(llava_path)
         self.vision_tower = CLIPVisionModel.from_pretrained(llava_path)
         self.vision_tower.requires_grad_(False)

--- a/options/SUPIR_v0.yaml
+++ b/options/SUPIR_v0.yaml
@@ -62,6 +62,7 @@ model:
         context_dim: 2048
         spatial_transformer_attn_type: softmax-xformers
         legacy: False
+        use_fp16: True
 
     conditioner_config:
       target: sgm.modules.GeneralConditionerWithControl
@@ -149,8 +150,8 @@ model:
         unreal engine, blurring, dirty, messy, worst quality, low quality, frames, watermark, signature, 
         jpeg artifacts, deformed, lowres, over-smooth'
 
-SDXL_CKPT: models/Juggernaut-XL_v9_RunDiffusionPhoto_v2.safetensors
-SUPIR_CKPT_F: models/v0F.ckpt
-SUPIR_CKPT_Q: models/v0Q.ckpt
+SDXL_CKPT: Juggernaut-XL_v9_RunDiffusionPhoto_v2.safetensors
+SUPIR_CKPT_F: SUPIR-v0F.ckpt
+SUPIR_CKPT_Q: SUPIR-v0Q.ckpt
 SUPIR_CKPT: ~
 

--- a/options/SUPIR_v0_tiled.yaml
+++ b/options/SUPIR_v0_tiled.yaml
@@ -126,7 +126,7 @@ model:
           target: torch.nn.Identity
 
     sampler_config:
-      target: sgm.modules.diffusionmodules.sampling.TiledRestoreEDMSampler
+      target: sgm.modules.diffusionmodules.sampling.TiledRestoreDPMPP2MSampler
       params:
         num_steps: 100
         restore_cfg: 4.0
@@ -151,8 +151,8 @@ model:
         unreal engine, blurring, dirty, messy, worst quality, low quality, frames, watermark, signature, 
         jpeg artifacts, deformed, lowres, over-smooth'
 
-SDXL_CKPT: models/Juggernaut-XL_v9_RunDiffusionPhoto_v2.safetensors
-SUPIR_CKPT_F: models/v0F.ckpt
-SUPIR_CKPT_Q: models/v0Q.ckpt
+SDXL_CKPT: Juggernaut-XL_v9_RunDiffusionPhoto_v2.safetensors
+SUPIR_CKPT_F: SUPIR-v0F.ckpt
+SUPIR_CKPT_Q: SUPIR-v0Q.ckpt
 SUPIR_CKPT: ~
 

--- a/requirements_kaggle.txt
+++ b/requirements_kaggle.txt
@@ -5,16 +5,14 @@ ffmpeg_progress_yield
 filetype==1.2.0
 k_diffusion
 Markdown==3.5.2
-numpy==1.26.4
-requests==2.31.0
 sentencepiece==0.2.0
 tokenizers # Leave this to be set by the installed transformers version
-uvicorn==0.28.0
+uvicorn
 wandb
 httpx
 transformers==4.38.2
 accelerate==0.27.2
-scikit-learn==1.4.1.post1
+scikit-learn
 sentencepiece
 einops==0.7.0
 einops-exts==0.0.4
@@ -22,28 +20,18 @@ timm==0.9.16
 openai-clip==1.0.1
 fsspec
 kornia==0.7.1
-matplotlib==3.8.3
+matplotlib==3.7.5
 ninja==1.11.1.1
 omegaconf==2.3.0
 open-clip-torch==2.24.0
 opencv-python==4.9.0.80
-pandas==2.2.1
-Pillow==10.2.0
+pandas==2.1.4
 pytorch-lightning # Leave this to be set by the installed torch version
-PyYAML==6.0.1
-scipy==1.12.0
-tqdm==4.66.2
-urllib3==2.2.1
+PyYAML
+tqdm
 webdataset==0.2.86
 fastapi
 diffusers
 facexlib==0.3.0
-torch==2.1.0
-torchvision
-torchaudio==2.1.0
-xformers
-# Only for windows
-https://huggingface.co/MonsterMMORPG/SECourses/resolve/main/triton-2.1.0-cp310-cp310-win_amd64.whl ; platform_system == "Windows"
---extra-index-url https://download.pytorch.org/whl/cu121
 
 

--- a/sgm/modules/encoders/modules.py
+++ b/sgm/modules/encoders/modules.py
@@ -16,6 +16,7 @@ from transformers import (
     CLIPTokenizer,
     T5EncoderModel,
     T5Tokenizer,
+    BitsAndBytesConfig
 )
 
 from SUPIR.utils.model_fetch import get_model
@@ -33,7 +34,7 @@ from ...util import (
     instantiate_from_config,
 )
 
-from CKPT_PTH import SDXL_CLIP1_PATH, SDXL_CLIP2_CKPT_PTH
+import CKPT_PTH  #import SDXL_CLIP1_PATH, SDXL_CLIP2_CKPT_PTH
 
 class AbstractEmbModel(nn.Module):
     def __init__(self):
@@ -444,6 +445,8 @@ class FrozenCLIPEmbedder(AbstractEmbModel):
 
     LAYERS = ["last", "pooled", "hidden"]
 
+  
+    
     def __init__(
         self,
         version="openai/clip-vit-large-patch14",
@@ -455,8 +458,10 @@ class FrozenCLIPEmbedder(AbstractEmbModel):
         always_return_pooled=False,
     ):  # clip-vit-base-patch32
         super().__init__()
+       
+
         assert layer in self.LAYERS
-        model_file = get_model(SDXL_CLIP1_PATH)
+        model_file = get_model(CKPT_PTH.SDXL_CLIP1_PATH)
         self.tokenizer = CLIPTokenizer.from_pretrained(model_file)
         self.transformer = CLIPTextModel.from_pretrained(model_file)
         self.device = device
@@ -525,11 +530,12 @@ class FrozenOpenCLIPEmbedder2(AbstractEmbModel):
     ):
         super().__init__()
         assert layer in self.LAYERS
-        model_path = get_model(SDXL_CLIP2_CKPT_PTH)
+
+        model_path = get_model(CKPT_PTH.SDXL_CLIP2_CKPT_PTH)
         model, _, _ = open_clip.create_model_and_transforms(
             arch,
             device=torch.device("cpu"),
-            pretrained=model_path,
+            pretrained=model_path                        
         )
         del model.visual
         self.model = model

--- a/test.py
+++ b/test.py
@@ -1,6 +1,6 @@
 import torch.cuda
 import argparse
-from SUPIR.util import create_SUPIR_model, PIL2Tensor, Tensor2PIL, convert_dtype
+from SUPIR.util import load_model_weights, PIL2Tensor, Tensor2PIL, convert_dtype
 from PIL import Image
 from llava.llava_agent import LLavaAgent
 from CKPT_PTH import LLAVA_MODEL_PATH
@@ -52,7 +52,7 @@ print(args)
 use_llava = not args.no_llava
 
 # load SUPIR
-model = create_SUPIR_model('options/SUPIR_v0.yaml', supir_sign=args.SUPIR_sign).to(SUPIR_device)
+model = load_model_weights('options/SUPIR_v0.yaml', supir_sign=args.SUPIR_sign).to(SUPIR_device)
 model.ae_dtype_radio = convert_dtype(args.ae_dtype)
 model.model.dtype = convert_dtype(args.diff_dtype)
 # load LLaVA


### PR DESCRIPTION
### Fixes for model loading and download:

- Run download_models.py is optional now. If run, the models will be saved in the default 'models' folder within the project root path. Checkpoints will be stored in the 'checkpoints' subfolder within the 'models' directory.
- The code is already prepared so that during execution it can carry out all necessary downloads in the default 'models' folder if it does not exist in the root directory.
- The options yaml file is no longer used to reference checkpoint names.
- With the exception of the automatic download script, all code will search for model names and parameterized checkpoints in the CKPT_PTH.py file. This file will receive the default 'models' base folder in the 'model_path' variable when the 'args.ckpt_dir' argument is not provided. I created a second variable 'model_path2' which is optional if you want to use a second path for the model (e.g. kaggle temp folder). This variable is defined when the 'args.ckpt_dir2' argument is entered. If the argument is not passed, it will receive the same value as 'model_path'.

**How to test:**

**Test 1**: (Do not enter any arguments for ckpt_dir and ckpt_dir2) - Remove the 'models' folder if it exists from the project root path. Just run the code and all the necessary templates will be automatically downloaded during execution.
**Test 2**: (Enter a different path for the ckpt_dir argument) All files will be downloaded in this informed path, if they already exist, they will be used, however the existing folder structure must match the pattern of how they are originally downloaded.
**Test 3**: (Enter a different path for the ckpt_dir2 argument) The laion clip model will be downloaded to this new path.
**Test 4**: - Delete the model folder in the project root and run 'download_models.py', it should download all models back to the default folder.

**Structure model folders:**

---> **models**
| ------**checkpoints** (Here is ckpt supir and others safetensor or ckpt files)
|
|**others models folders/subfolders** (it is like model_id e.g: 'laion/CLIP-ViT-bigG-14-laion2B-39B-b160k' like subfolder)

### Fix for FP16 on Kaggle
For Kaggle you need start with follow params:

For FP16:
!python gradio_demo.py --loading_half_params --use_tile_vae --load_4bit_llava --ckpt_dir /kaggle/temp/models

For FP8:
!python gradio_demo.py --fp8  --use_tile_vae --load_4bit_llava --ckpt_dir /kaggle/temp/models

The best way to test is to use the notebook that I have already made available as there are also some dependency adjustments for the installation. For Kaggle, a separate requirements file called requirements_kaggle.txt was created.

Other changes:
FP8: --fp8 new parameter to use FP8, do not require --loading_half_params together