### PR TITLE
Fixes: FP16, Kaggle and Sampler parameter

### DIFF
--- a/SUPIR/util.py
+++ b/SUPIR/util.py
@@ -24,8 +24,7 @@ def load_state_dict(ckpt_path, location='cpu'):
         state_dict = safetensors.torch.load_file(ckpt_path, device=location)
     else:
         state_dict = get_state_dict(torch.load(ckpt_path, map_location=torch.device(location)))
-    state_dict = get_state_dict(state_dict)
-    print(f'Loaded state_dict from [{ckpt_path}]')
+    state_dict = get_state_dict(state_dict)    
     return state_dict
 
 

--- a/SUPIR/util.py
+++ b/SUPIR/util.py
@@ -10,7 +10,7 @@ from .utils import models_utils
 from omegaconf import OmegaConf
 from sgm.util import instantiate_from_config
 from ui_helpers import printt
-from SUPIR.utils import models_utils, sd_model_initialization
+from SUPIR.utils import models_utils, sd_model_initialization, shared
 
 def get_state_dict(d):
     return d.get('state_dict', d)
@@ -41,8 +41,14 @@ def create_SUPIR_model(config_path, weight_dtype='bf16', supir_sign=None, device
         '': convert_dtype(weight_dtype),
     }   
     # Instantiate model from config
-    printt(f'Loading model from [{config_path}]')    
-    model = instantiate_from_config(config.model)
+    printt(f'Loading model from [{config_path}]')
+    if shared.opts.fast_load_sd:
+        with sd_model_initialization.DisableInitialization(disable_clip=False):
+            with sd_model_initialization.InitializeOnMeta():    
+                model = instantiate_from_config(config.model)
+    else:
+        model = instantiate_from_config(config.model)
+
     printt(f'Loaded model from [{config_path}]')
 
     # Function to load state dict to the chosen device

--- a/SUPIR/utils/sd_model_initialization.py
+++ b/SUPIR/utils/sd_model_initialization.py
@@ -1,0 +1,226 @@
+import sgm.modules.encoders.modules
+import open_clip
+import torch
+import transformers.utils.hub
+
+class ReplaceHelper:
+    def __init__(self):
+        self.replaced = []
+
+    def replace(self, obj, field, func):
+        original = getattr(obj, field, None)
+        if original is None:
+            return None
+
+        self.replaced.append((obj, field, original))
+        setattr(obj, field, func)
+
+        return original
+
+    def restore(self):
+        for obj, field, original in self.replaced:
+            setattr(obj, field, original)
+
+        self.replaced.clear()
+
+class DisableInitialization(ReplaceHelper):
+    """
+    When an object of this class enters a `with` block, it starts:
+    - preventing torch's layer initialization functions from working
+    - changes CLIP and OpenCLIP to not download model weights
+    - changes CLIP to not make requests to check if there is a new version of a file you already have
+
+    When it leaves the block, it reverts everything to how it was before.
+
+    Use it like this:
+    ```
+    with DisableInitialization():
+        do_things()
+    ```
+    """
+
+    def __init__(self, disable_clip=True):
+        super().__init__()
+        self.disable_clip = disable_clip
+
+    def replace(self, obj, field, func):
+        original = getattr(obj, field, None)
+        if original is None:
+            return None
+
+        self.replaced.append((obj, field, original))
+        setattr(obj, field, func)
+
+        return original
+
+    def __enter__(self):
+        def do_nothing(*args, **kwargs):
+            pass
+
+        def create_model_and_transforms_without_pretrained(*args, pretrained=None, **kwargs):
+            return self.create_model_and_transforms(*args, pretrained=None, **kwargs)
+
+        def CLIPTextModel_from_pretrained(pretrained_model_name_or_path, *model_args, **kwargs):
+            res = self.CLIPTextModel_from_pretrained(None, *model_args, config=pretrained_model_name_or_path, state_dict={}, **kwargs)
+            res.name_or_path = pretrained_model_name_or_path
+            return res
+
+        def transformers_modeling_utils_load_pretrained_model(*args, **kwargs):
+            args = args[0:3] + ('/', ) + args[4:]  # resolved_archive_file; must set it to something to prevent what seems to be a bug
+            return self.transformers_modeling_utils_load_pretrained_model(*args, **kwargs)
+
+        def transformers_utils_hub_get_file_from_cache(original, url, *args, **kwargs):
+
+            # this file is always 404, prevent making request
+            if url == 'https://huggingface.co/openai/clip-vit-large-patch14/resolve/main/added_tokens.json' or url == 'openai/clip-vit-large-patch14' and args[0] == 'added_tokens.json':
+                return None
+
+            try:
+                res = original(url, *args, local_files_only=True, **kwargs)
+                if res is None:
+                    res = original(url, *args, local_files_only=False, **kwargs)
+                return res
+            except Exception:
+                return original(url, *args, local_files_only=False, **kwargs)
+
+        def transformers_utils_hub_get_from_cache(url, *args, local_files_only=False, **kwargs):
+            return transformers_utils_hub_get_file_from_cache(self.transformers_utils_hub_get_from_cache, url, *args, **kwargs)
+
+        def transformers_tokenization_utils_base_cached_file(url, *args, local_files_only=False, **kwargs):
+            return transformers_utils_hub_get_file_from_cache(self.transformers_tokenization_utils_base_cached_file, url, *args, **kwargs)
+
+        def transformers_configuration_utils_cached_file(url, *args, local_files_only=False, **kwargs):
+            return transformers_utils_hub_get_file_from_cache(self.transformers_configuration_utils_cached_file, url, *args, **kwargs)
+
+        self.replace(torch.nn.init, 'kaiming_uniform_', do_nothing)
+        self.replace(torch.nn.init, '_no_grad_normal_', do_nothing)
+        self.replace(torch.nn.init, '_no_grad_uniform_', do_nothing)
+
+        if self.disable_clip:
+            self.create_model_and_transforms = self.replace(open_clip, 'create_model_and_transforms', create_model_and_transforms_without_pretrained)
+            self.CLIPTextModel_from_pretrained = self.replace(sgm.modules.encoders.modules.CLIPTextModel, 'from_pretrained', CLIPTextModel_from_pretrained)
+            self.transformers_modeling_utils_load_pretrained_model = self.replace(transformers.modeling_utils.PreTrainedModel, '_load_pretrained_model', transformers_modeling_utils_load_pretrained_model)
+            self.transformers_tokenization_utils_base_cached_file = self.replace(transformers.tokenization_utils_base, 'cached_file', transformers_tokenization_utils_base_cached_file)
+            self.transformers_configuration_utils_cached_file = self.replace(transformers.configuration_utils, 'cached_file', transformers_configuration_utils_cached_file)
+            self.transformers_utils_hub_get_from_cache = self.replace(transformers.utils.hub, 'get_from_cache', transformers_utils_hub_get_from_cache)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.restore()
+
+
+class InitializeOnMeta(ReplaceHelper):
+    """
+    Context manager that causes all parameters for linear/conv2d/mha layers to be allocated on meta device,
+    which results in those parameters having no values and taking no memory. model.to() will be broken and
+    will need to be repaired by using LoadStateDictOnMeta below when loading params from state dict.
+
+    Usage:
+    ```
+    with sd_model_initialization.InitializeOnMeta():
+        sd_model = instantiate_from_config(sd_config.model)
+    ```
+    """
+
+    def __enter__(self):
+        # if shared.cmd_opts.disable_model_loading_ram_optimization:
+        #     return
+
+        def set_device(x):
+            x["device"] = "meta"
+            return x
+
+        linear_init = self.replace(torch.nn.Linear, '__init__', lambda *args, **kwargs: linear_init(*args, **set_device(kwargs)))
+        conv2d_init = self.replace(torch.nn.Conv2d, '__init__', lambda *args, **kwargs: conv2d_init(*args, **set_device(kwargs)))
+        mha_init = self.replace(torch.nn.MultiheadAttention, '__init__', lambda *args, **kwargs: mha_init(*args, **set_device(kwargs)))
+        self.replace(torch.nn.Module, 'to', lambda *args, **kwargs: None)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.restore()
+
+
+class LoadStateDictOnMeta(ReplaceHelper):
+    """
+    Context manager that allows to read parameters from state_dict into a model that has some of its parameters in the meta device.
+    As those parameters are read from state_dict, they will be deleted from it, so by the end state_dict will be mostly empty, to save memory.
+    Meant to be used together with InitializeOnMeta above.
+
+    Usage:
+    ```
+    with sd_model_initialization.LoadStateDictOnMeta(state_dict):
+        model.load_state_dict(state_dict, strict=False)
+    ```
+    """
+
+    def __init__(self, state_dict, device, weight_dtype_conversion=None):
+        super().__init__()
+        self.state_dict = state_dict
+        self.device = device
+        self.weight_dtype_conversion = weight_dtype_conversion or {}
+        self.default_dtype = self.weight_dtype_conversion.get('')
+
+    def get_weight_dtype(self, key):
+        key_first_term, _ = key.split('.', 1)
+        return self.weight_dtype_conversion.get(key_first_term, self.default_dtype)
+
+    def __enter__(self):      
+
+        sd = self.state_dict
+        device = self.device
+
+        def load_from_state_dict(original, module, state_dict, prefix, *args, **kwargs):
+            used_param_keys = []
+
+            for name, param in module._parameters.items():
+                if param is None:
+                    continue
+
+                key = prefix + name
+                sd_param = sd.pop(key, None)
+                if sd_param is not None:
+                    state_dict[key] = sd_param.to(dtype=self.get_weight_dtype(key))
+                    used_param_keys.append(key)
+
+                if param.is_meta:
+                    dtype = sd_param.dtype if sd_param is not None else param.dtype
+                    module._parameters[name] = torch.nn.parameter.Parameter(torch.zeros_like(param, device=device, dtype=dtype), requires_grad=param.requires_grad)
+
+            for name in module._buffers:
+                key = prefix + name
+
+                sd_param = sd.pop(key, None)
+                if sd_param is not None:
+                    state_dict[key] = sd_param
+                    used_param_keys.append(key)
+
+            original(module, state_dict, prefix, *args, **kwargs)
+
+            for key in used_param_keys:
+                state_dict.pop(key, None)
+
+        def load_state_dict(original, module, state_dict, strict=True):
+            """torch makes a lot of copies of the dictionary with weights, so just deleting entries from state_dict does not help
+            because the same values are stored in multiple copies of the dict. The trick used here is to give torch a dict with
+            all weights on meta device, i.e. deleted, and then it doesn't matter how many copies torch makes.
+
+            In _load_from_state_dict, the correct weight will be obtained from a single dict with the right weights (sd).
+
+            The dangerous thing about this is if _load_from_state_dict is not called, (if some exotic module overloads
+            the function and does not call the original) the state dict will just fail to load because weights
+            would be on the meta device.
+            """
+
+            if state_dict is sd:
+                state_dict = {k: v.to(device="meta", dtype=v.dtype) for k, v in state_dict.items()}
+
+            original(module, state_dict, strict=strict)
+
+        module_load_state_dict = self.replace(torch.nn.Module, 'load_state_dict', lambda *args, **kwargs: load_state_dict(module_load_state_dict, *args, **kwargs))
+        module_load_from_state_dict = self.replace(torch.nn.Module, '_load_from_state_dict', lambda *args, **kwargs: load_from_state_dict(module_load_from_state_dict, *args, **kwargs))
+        linear_load_from_state_dict = self.replace(torch.nn.Linear, '_load_from_state_dict', lambda *args, **kwargs: load_from_state_dict(linear_load_from_state_dict, *args, **kwargs))
+        conv2d_load_from_state_dict = self.replace(torch.nn.Conv2d, '_load_from_state_dict', lambda *args, **kwargs: load_from_state_dict(conv2d_load_from_state_dict, *args, **kwargs))
+        mha_load_from_state_dict = self.replace(torch.nn.MultiheadAttention, '_load_from_state_dict', lambda *args, **kwargs: load_from_state_dict(mha_load_from_state_dict, *args, **kwargs))
+        layer_norm_load_from_state_dict = self.replace(torch.nn.LayerNorm, '_load_from_state_dict', lambda *args, **kwargs: load_from_state_dict(layer_norm_load_from_state_dict, *args, **kwargs))
+        group_norm_load_from_state_dict = self.replace(torch.nn.GroupNorm, '_load_from_state_dict', lambda *args, **kwargs: load_from_state_dict(group_norm_load_from_state_dict, *args, **kwargs))
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.restore()

--- a/SUPIR/utils/shared.py
+++ b/SUPIR/utils/shared.py
@@ -5,3 +5,4 @@ opts.fp8_storage=False
 opts.opt_channelslast=False
 opts.half_mode = False
 opts.upcast_sampling = False
+opts.fast_load_sd = False

--- a/SUPIR/utils/tilevae.py
+++ b/SUPIR/utils/tilevae.py
@@ -712,6 +712,7 @@ class VAEHook:
             else:
                 return self.vae_tile_forward(x)
         finally:
+            devices.torch_gc()
             pass
 
     def get_best_tile_size(self, lowerbound, upperbound):

--- a/gradio_demo.py
+++ b/gradio_demo.py
@@ -945,7 +945,7 @@ def supir_process(inputs: List[MediaData], a_prompt, n_prompt, num_samples,
                                                 num_samples=num_samples, p_p=a_prompt, n_p=n_prompt,
                                                 color_fix_type=color_fix_type,
                                                 use_linear_cfg=linear_cfg, use_linear_control_scale=linear_s_stage2,
-                                                cfg_scale_start=spt_linear_cfg, control_scale_start=spt_linear_s_stage2)
+                                                cfg_scale_start=spt_linear_cfg, control_scale_start=spt_linear_s_stage2, sampler_cls=sampler)
 
                 if is_face and face_resolution < 1024:
                     samples = samples[:, :, 512 - face_resolution // 2:512 + face_resolution // 2,

--- a/gradio_demo.py
+++ b/gradio_demo.py
@@ -42,6 +42,8 @@ parser.add_argument("--loading_half_params", action='store_true', default=False,
                     help="Enable loading model parameters in half precision to reduce memory usage.")
 parser.add_argument("--fp8", action='store_true', default=False, 
                     help="Enable loading model parameters in FP8 precision to reduce memory usage.")
+parser.add_argument("--fast_load_sd", action='store_true', default=False, 
+                    help="Enable fast loading of model state dict and to prevents unnecessary memory allocation.")
 parser.add_argument("--use_tile_vae", action='store_true', default=True,
                     help="Enable tiling for the VAE to handle larger images with limited memory.")
 parser.add_argument("--outputs_folder_button", type=str, default=False, help="Outputs Folder Button Will Be Enabled")
@@ -95,6 +97,7 @@ if torch.cuda.is_available():
         print("Loading half params")
 
 shared.opts.half_mode = args.loading_half_params  
+shared.opts.fast_load_sd = args.fast_load_sd
 
 if args.fp8:
     shared.opts.half_mode = args.fp8

--- a/requirements_kaggle.txt
+++ b/requirements_kaggle.txt
@@ -1,0 +1,37 @@
+gradio==4.19.0
+gradio_imageslider
+gradio_client
+ffmpeg_progress_yield
+filetype==1.2.0
+k_diffusion
+Markdown==3.5.2
+sentencepiece==0.2.0
+tokenizers # Leave this to be set by the installed transformers version
+uvicorn
+wandb
+httpx
+transformers==4.38.2
+accelerate==0.27.2
+scikit-learn
+sentencepiece
+einops==0.7.0
+einops-exts==0.0.4
+timm==0.9.16
+openai-clip==1.0.1
+fsspec
+kornia==0.7.1
+matplotlib==3.7.5
+ninja==1.11.1.1
+omegaconf==2.3.0
+open-clip-torch==2.24.0
+opencv-python==4.9.0.80
+pandas==2.1.4
+pytorch-lightning # Leave this to be set by the installed torch version
+PyYAML
+tqdm
+webdataset==0.2.86
+fastapi
+diffusers
+facexlib==0.3.0
+
+


### PR DESCRIPTION
Fixes: FP16, Kaggle and Sampler parameter

For FP16 it will be forced if GPU do not support BF16.

For Kaggle i created `--fast_load_sd` parameter. It enable fast loading of model state dict and to prevents unnecessary CPU RAM allocation. Will reduce CPU RAM usage on kaggle, but it increase in +/- 2.5GB GPU VRAM usage. It can be used locally too to save RAM if it is a problem but will increase GPU VRAM usage too. 

To avoid warning on terminal, set envrionment variable before run:

`SET PYTHONWARNINGS=ignore`

I included requirements for kaggle to avoid dependencies errors on Kaggle,
On notebook i used this:
```
%env PYTHONWARNINGS=ignore
%env PYTORCH_CUDA_ALLOC_CONF=garbage_collection_threshold:0.9,max_split_size_mb:256
%cd /kaggle/working/SUPIR
!pip install torch==2.1.2 torchvision==0.16.2 torchaudio==2.1.2 --index-url https://download.pytorch.org/whl/cu121 --upgrade
!pip uninstall xformers -y
!pip install xformers==0.0.23.post1 --index-url https://download.pytorch.org/whl/cu121 --upgrade  
!pip install bitsandbytes==0.43.0 --upgrade
!pip install -r requirements_kaggle.txt
!pip install huggingface_hub
!pip install flask
!pip install pyngrok
!python -m xformers.info
```