### PR TITLE
Fixed an issue where "restoring faces only", would result in no output

### DIFF
--- a/gradio_demo.py
+++ b/gradio_demo.py
@@ -994,10 +994,13 @@ def supir_process(inputs: List[MediaData], a_prompt, n_prompt, num_samples,
                 else:
                     result = _bg[0]
 
-            # I couldnt make this part
-            # if not apply_bg and apply_face:
-            #    face_helper.get_inverse_affine(None)
-            #    result = face_helper.paste_faces_to_input_image(upsample_img=lq)
+            if not apply_bg and apply_face:                
+                face_helper.get_inverse_affine(None)
+
+                # the image the face helper is using is already scaled to the desired resolution using lanzcos
+                # I believe the output from this function should be just the original image but with only the face
+                # restoration. 
+                result = face_helper.paste_faces_to_input_image()
 
             if not apply_face and not apply_bg:
                 caption = [img_prompt]


### PR DESCRIPTION
The bug being fixed:
Run SupIR in batch mode, select restore faces, but do not select restore BG. When running in batch, the output with the restored faces was not being saved.

Fixed this by saving the restored images onto the original image (post upscale).

Note: Please make sure my code is in line with your intentions for the feature. I am new to this codebase.